### PR TITLE
Unit tests for boundary constraint parsing, etc.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *.gem
 *.swp
+*.bat
+*.lnk
 .yardoc*
 .rbenv-version
 Gemfile.lock

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 ## CHANGELOG
 
+- __2015/03/dd__: 0.9.9 release.
+    - Issue 21: Implemented boundary constraint parsing.
+    - Issue 26: Removing deprecated methods parse_as_nodes, parse_as_strings, readnodes and readlines.
+
 - __2015/02/10__: 0.9.8 release.
     - Migrated natto code home from Bitbucket to GitHub.
     - Improved documentation following said migration.
@@ -7,16 +11,10 @@
     - Updating LICENSE for year 2015. 
 
 - __2014/12/20__: 0.9.7 release.
-    - Issue 14: [adding automatic discovery for mecab library; no need to
-	explicitly set
-	MECAB_PATH!](https://bitbucket.org/buruzaemon/natto/issue/14/automatic-discovery-of-libmecab-path-and)
-    - Issue 15: [refactored node-parsing to use Enumerator instead of
-	materializing every node and stuffing into
-	array](https://bitbucket.org/buruzaemon/natto/issue/15/use-enumerator-when-parsing-mecab-nodes)
-    - Issue 17: [adding filepath to MeCab and
-	DictionaryInfo](https://bitbucket.org/buruzaemon/natto/issue/17/use-filerealpath-value-for-all-file-paths)
-    - Issue 18: [bug-fix for node-formatting during default node
-	parse](https://bitbucket.org/buruzaemon/natto/issue/18/no-node-formatting-when-using-default-node)
+    - Issue 14: adding automatic discovery for mecab library; no need to explicitly set MECAB_PATH
+    - Issue 15: refactored node-parsing to use Enumerator instead of materializing every node and stuffing into array
+    - Issue 17: adding filepath to MeCab and DictionaryInfo
+    - Issue 18: bug-fix for node-formatting during default node parse
     - Deprecating parse_as_nodes and parse_as_strings; please use parse instead!
     - CAUTION: parse_as_nodes, parse_as_strings, readnodes and readlines will be removed in the following release!
     - Enhancements to to_s methods for both MeCab and DictionaryInfo
@@ -36,8 +34,8 @@
     - Removing automatic library load for Cygwin platform (does not compile) 
 
 - __2012/09/16__: 0.9.5 release.
-    - Fixed [Issue 9: trimされていない文字列のparse](https://bitbucket.org/buruzaemon/natto/issue/9/trim-parse) 
-    - Fixed [Issue 10: BUG Segmentation Fault](https://bitbucket.org/buruzaemon/natto/issue/10/bug-segmentation-fault) 
+    - Fixed Issue 9: trimされていない文字列のparse
+    - Fixed Issue 10: BUG Segmentation Fault
     - Adding parse_as_nodes to allow for method-chaining on list of parsed nodes
     - Adding parse_as_strings to allow for method-chaining on list of string output
     - Deprecating both readnodes and readlines (badly named methods, see parse_as_nodes and parse_as_strings, respectively)

--- a/README.md
+++ b/README.md
@@ -46,12 +46,12 @@ However, if you are using a CRuby on Windows, then you will first need to instal
 
 
 ## Automatic Configuration
-***No explicit configuration should be necessary, as natto will try to locate the `mecab` library based upon its runtime environment.***
+No explicit configuration should be necessary, as natto will try to locate the MeCab library based upon its runtime environment.
 - On OS X and \*nix, it will query `mecab-config --libs` 
 - On Windows, it will query the Windows Registry to determine where `libmecab.dll` is installed
 
 ## Explicit configuration via `MECAB_PATH` and `MECAB_CHARSET`
-***If natto cannot find the `mecab` library, `LoadError` will be raised.*** Please set the `MECAB_PATH` environment variable to the exact name/path to your `mecab` library.
+If natto cannot find the MeCab library, `LoadError` will be raised. Please set the `MECAB_PATH` environment variable to the exact name/path to your MeCab library.
 
 - e.g., for OS X
 
@@ -74,7 +74,6 @@ However, if you are using a CRuby on Windows, then you will first need to instal
 Here's a very quick guide to using natto.
 
 Instantiate a reference to the MeCab library, and display some details:
-
 
     require 'natto'
 
@@ -129,38 +128,39 @@ Parse Japanese text and send the MeCab result as a single string to stdout:
 
 ----
 
-If a block is passed to `parse`, you can iterate over
-the list of resulting `MeCabNode` instances to access 
-more detailed information about each morpheme. 
+If a block is passed to `parse`, you can iterate over the list of resulting `MeCabNode`
+instances to access more detailed information about each morpheme. 
 
-In this example, the following attributes and methods
-for `MeCabNode` are used:
-
+In this example, the following attributes and methods for `MeCabNode` are used:
 - `surface` - the morpheme surface
-- `posid` - node part-of-speech ID (dictionary-dependent) 
+- `posid` - node part-of-speech ID (dictionary-dependent)
 - `is_eos?` - is this `MeCabNode` an end-of-sentence node?
 
+This iterates over the morpheme nodes in the given text,
+and outputs a formatted, tab-delimited line with the
+morpheme surface and part-of-speech ID, ignoring any end-of-sentence
+nodes:
 
-        nm.parse('世界チャンプ目指してんだなこれがっ!!夢なの、俺のっ!!') do |n|
-          puts "#{n.surface}\tpart-of-speech id: #{n.posid}" if !n.is_eos?
-        end
-        世界    part-of-speech id: 38
-        チャンプ        part-of-speech id: 38
-        目指し  part-of-speech id: 31
-        て      part-of-speech id: 18
-        ん      part-of-speech id: 63
-        だ      part-of-speech id: 25
-        な      part-of-speech id: 17
-        これ    part-of-speech id: 59
-        がっ    part-of-speech id: 32
-        !!      part-of-speech id: 36
-        夢      part-of-speech id: 38
-        な      part-of-speech id: 25
-        の      part-of-speech id: 17
-        、      part-of-speech id: 9
-        俺      part-of-speech id: 59
-        のっ    part-of-speech id: 31
-        !!      part-of-speech id: 36
+    nm.parse('世界チャンプ目指してんだなこれがっ!!夢なの、俺のっ!!') do |n|
+      puts "#{n.surface}\tpart-of-speech id: #{n.posid}" if !n.is_eos?
+    end
+    世界    part-of-speech id: 38
+    チャンプ        part-of-speech id: 38
+    目指し  part-of-speech id: 31
+    て      part-of-speech id: 18
+    ん      part-of-speech id: 63
+    だ      part-of-speech id: 25
+    な      part-of-speech id: 17
+    これ    part-of-speech id: 59
+    がっ    part-of-speech id: 32
+    !!      part-of-speech id: 36
+    夢      part-of-speech id: 38
+    な      part-of-speech id: 25
+    の      part-of-speech id: 17
+    、      part-of-speech id: 9
+    俺      part-of-speech id: 59
+    のっ    part-of-speech id: 31
+    !!      part-of-speech id: 36
 
 ----
 
@@ -178,46 +178,49 @@ the resulting `MeCabNode` feature attribute to extract:
 - `%f[0]` - node part-of-speech
 - `%f[7]` - reading
 
-        nm = Natto::MeCab.new('-F%m\t%f[0]\t%f[7]')
+Note that we can move the `Enumerator` both forwards and backwards, rewind it
+back to the beginning, and then iterate over it.
+
+    nm = Natto::MeCab.new('-F%m\t%f[0]\t%f[7]')
     
-        enum = nm.enum_parse('この星の一等賞になりたいの卓球で俺は、そんだけ！')
-        => #<Enumerator: #<Enumerator::Generator:0x00000002ff3898>:each>
+    enum = nm.enum_parse('この星の一等賞になりたいの卓球で俺は、そんだけ！')
+    => #<Enumerator: #<Enumerator::Generator:0x00000002ff3898>:each>
     
-        enum.next
-        => #<Natto::MeCabNode:0x000000032eed68 \
-             @pointer=#<FFI::Pointer address=0x000000005ffb48>, \
-             stat=0, \
-             @surface="この", \
-             @feature="この   連体詞  コノ">
+    enum.next
+    => #<Natto::MeCabNode:0x000000032eed68 \
+         @pointer=#<FFI::Pointer address=0x000000005ffb48>, \
+         stat=0, \
+         @surface="この", \
+         @feature="この   連体詞  コノ">
     
-        enum.peek
-        => #<Natto::MeCabNode:0x00000002fe2110a \
-             @pointer=#<FFI::Pointer address=0x000000005ffdb8>, \
-             stat=0, \
-             @surface="星", \
-             @feature="星       名詞    ホシ"> 
+    enum.peek
+    => #<Natto::MeCabNode:0x00000002fe2110a \
+         @pointer=#<FFI::Pointer address=0x000000005ffdb8>, \
+         stat=0, \
+         @surface="星", \
+         @feature="星       名詞    ホシ"> 
         
-        enum.rewind
+    enum.rewind
     
-        # again, ignore any end-of-sentence nodes
-        enum.each { |n| puts n.feature if !n.is_eos? }
-        この    連体詞  コノ
-        星      名詞    ホシ
-        の      助詞    ノ
-        一等    名詞    イットウ
-        賞      名詞    ショウ
-        に      助詞    ニ
-        なり    動詞    ナリ
-        たい    助動詞  タイ
-        の      助詞    ノ
-        卓球    名詞    タッキュウ
-        で      助詞    デ
-        俺      名詞    オレ
-        は      助詞    ハ
-        、      記号    、
-        そん    名詞    ソン
-        だけ    助詞    ダケ
-        ！      記号    ！
+    # again, ignore any end-of-sentence nodes
+    enum.each { |n| puts n.feature if !n.is_eos? }
+    この    連体詞  コノ
+    星      名詞    ホシ
+    の      助詞    ノ
+    一等    名詞    イットウ
+    賞      名詞    ショウ
+    に      助詞    ニ
+    なり    動詞    ナリ
+    たい    助動詞  タイ
+    の      助詞    ノ
+    卓球    名詞    タッキュウ
+    で      助詞    デ
+    俺      名詞    オレ
+    は      助詞    ハ
+    、      記号    、
+    そん    名詞    ソン
+    だけ    助詞    ダケ
+    ！      記号    ！
 
 
 ## Learn more 

--- a/lib/natto/natto.rb
+++ b/lib/natto/natto.rb
@@ -197,13 +197,13 @@ module Natto
         # N-Best parsing implementations
         self.mecab_set_lattice_level(@tagger, (@options[:lattice_level] || 1))
 
-        @parse_tostr = lambda do |text| 
+        @parse_tostr = ->(text) {
           retval = self.mecab_nbest_sparse_tostr(@tagger, @options[:nbest], text) || 
                 raise(MeCabError.new(self.mecab_strerror(@tagger))) 
           retval.force_encoding(Encoding.default_external)
-        end 
+        } 
 
-        @parse_tonodes = lambda do |text| 
+        @parse_tonodes = ->(text) { 
           Enumerator.new do |y|
             self.mecab_nbest_init(@tagger, text) 
             n = self.mecab_nbest_next_tonode(@tagger)
@@ -233,16 +233,16 @@ module Natto
               n = self.mecab_nbest_next_tonode(@tagger)
             end
           end
-        end
+        }
       else
         # default parsing implementations
-        @parse_tostr = lambda do |text|
+        @parse_tostr = ->(text) {
           retval = self.mecab_sparse_tostr(@tagger, text) || 
                 raise(MeCabError.new(self.mecab_strerror(@tagger))) 
           retval.force_encoding(Encoding.default_external)
-        end
+        }
 
-        @parse_tonodes = lambda do |text| 
+        @parse_tonodes = ->(text) { 
           Enumerator.new do |y|
             n = self.mecab_sparse_tonode(@tagger, text) 
             raise(MeCabError.new(self.mecab_strerror(@tagger))) if n.nil? || n.address==0x0
@@ -266,7 +266,7 @@ module Natto
               n = mn.next
             end
           end
-        end
+        }
       end
 
       @dicts << Natto::DictionaryInfo.new(Natto::Binding.mecab_dictionary_info(@tagger))

--- a/lib/natto/natto.rb
+++ b/lib/natto/natto.rb
@@ -203,11 +203,13 @@ module Natto
       self.mecab_set_all_morphs(@tagger, 1) if @options[:all_morphs]
       self.mecab_set_partial(@tagger, 1) if @options[:partial]
        
-      # Set for parsing to string; for parsing to nodes,
-      # and for boundary constraing parsing to string; and to nodes.
+      # Define lambda for each major parsing type: _tostr, _tonode,
+      # boundary constraint _tostr, boundary constraint _node;
+      # and each parsing type will support both normal and N-best
+      # options
       @parse_tostr = ->(text) {
         if @options[:nbest] && @options[:nbest] > 1
-          self.mecab_set_lattice_level(@tagger, (@options[:lattice_level] || 1))
+          #self.mecab_set_lattice_level(@tagger, (@options[:lattice_level] || 1))
           retval = self.mecab_nbest_sparse_tostr(@tagger, @options[:nbest], text) || 
                 raise(MeCabError.new(self.mecab_strerror(@tagger))) 
         else
@@ -222,7 +224,7 @@ module Natto
         Enumerator.new do |y|
           if @options[:nbest] && @options[:nbest] > 1
             nlen = @options[:nbest]
-            self.mecab_set_lattice_level(@tagger, (@options[:lattice_level] || 1))
+            #self.mecab_set_lattice_level(@tagger, (@options[:lattice_level] || 1))
             self.mecab_nbest_init(@tagger, text) 
             nptr = self.mecab_nbest_next_tonode(@tagger)
           else

--- a/lib/natto/natto.rb
+++ b/lib/natto/natto.rb
@@ -105,6 +105,18 @@ module Natto
     include Natto::Binding
     include Natto::OptionParse
  
+    MECAB_LATTICE_ONE_BEST = 1
+    MECAB_LATTICE_NBEST = 2
+    MECAB_LATTICE_PARTIAL = 4
+    MECAB_LATTICE_MARGINAL_PROB = 8
+    MECAB_LATTICE_ALTERNATIVE = 16
+    MECAB_LATTICE_ALL_MORPHS = 32
+    MECAB_LATTICE_ALLOCATE_SENTENCE = 64
+
+    MECAB_ANY_BOUNDARY = 0
+    MECAB_TOKEN_BOUNDARY = 1
+    MECAB_INSIDE_TOKEN = 2
+
     # @return [FFI:Pointer] pointer to MeCab tagger.
     attr_reader :tagger
     # @return [String] absolute filepath to MeCab library.
@@ -191,31 +203,149 @@ module Natto
       self.mecab_set_all_morphs(@tagger, 1) if @options[:all_morphs]
       self.mecab_set_partial(@tagger, 1) if @options[:partial]
        
-      # Set mecab parsing implementations for N-best and regular parsing,
-      # for both parsing as string and yielding a node object
-      if @options[:nbest] && @options[:nbest] > 1
-        # N-Best parsing implementations
-        self.mecab_set_lattice_level(@tagger, (@options[:lattice_level] || 1))
-
-        @parse_tostr = ->(text) {
+      # Set for parsing to string; for parsing to nodes,
+      # and for boundary constraing parsing to string; and to nodes.
+      @parse_tostr = ->(text) {
+        if @options[:nbest] && @options[:nbest] > 1
+          self.mecab_set_lattice_level(@tagger, (@options[:lattice_level] || 1))
           retval = self.mecab_nbest_sparse_tostr(@tagger, @options[:nbest], text) || 
                 raise(MeCabError.new(self.mecab_strerror(@tagger))) 
-          retval.force_encoding(Encoding.default_external)
-        } 
+        else
+          retval = self.mecab_sparse_tostr(@tagger, text) || 
+                raise(MeCabError.new(self.mecab_strerror(@tagger))) 
+        end
 
-        @parse_tonodes = ->(text) { 
-          Enumerator.new do |y|
-            self.mecab_nbest_init(@tagger, text) 
-            n = self.mecab_nbest_next_tonode(@tagger)
-            raise(MeCabError.new(self.mecab_strerror(@tagger))) if n.nil? || n.address==0x0
+        retval.force_encoding(Encoding.default_external)
+      } 
 
+      @parse_tonodes = ->(text) { 
+        Enumerator.new do |y|
+          if @options[:nbest] && @options[:nbest] > 1
             nlen = @options[:nbest]
-            nlen.times do |i|
-              s = text.bytes.to_a
-              while n && n.address != 0x0
-                mn = Natto::MeCabNode.new(n)
-                # ignore BOS nodes, since mecab does so
-                if !mn.is_bos?
+            self.mecab_set_lattice_level(@tagger, (@options[:lattice_level] || 1))
+            self.mecab_nbest_init(@tagger, text) 
+            nptr = self.mecab_nbest_next_tonode(@tagger)
+          else
+            nlen = 1
+            nptr = self.mecab_sparse_tonode(@tagger, text) 
+          end
+          raise(MeCabError.new(self.mecab_strerror(@tagger))) if nptr.nil? || nptr.address==0x0
+
+          nlen.times do
+            s = text.bytes.to_a
+            while nptr && nptr.address != 0x0
+              mn = Natto::MeCabNode.new(nptr)
+              # ignore BOS nodes, since mecab does so
+              if !mn.is_bos?
+                s = s.drop_while {|e| (e==0xa || e==0x20)}
+                if !s.empty?
+                  sarr = []
+                  mn.length.times { sarr << s.shift }
+                  surf = sarr.pack('C*')
+                  mn.surface = surf.force_encoding(Encoding.default_external)
+                end
+                if @options[:output_format_type] || @options[:node_format]
+                  mn.feature = self.mecab_format_node(@tagger, nptr).force_encoding(Encoding.default_external)
+                end
+                y.yield mn
+              end
+              nptr = mn.next
+            end
+            if nlen > 1
+              nptr = self.mecab_nbest_next_tonode(@tagger)
+            end
+          end
+        end
+      }
+      
+      @bcparse_tostr = ->(text, boundary_constraints=/./) {
+        begin
+          lattice = self.mecab_lattice_new()
+          raise MeCabError.new("Could not create Lattice") if lattice.address == 0x0
+
+          if @options[:nbest] && @options[:nbest] > 1
+            n = @options[:nbest]
+            self.mecab_lattice_set_request_type(lattice, MECAB_LATTICE_NBEST)
+          else
+            n = 1
+            self.mecab_lattice_set_request_type(lattice, MECAB_LATTICE_ONE_BEST)
+          end
+
+          self.mecab_lattice_set_sentence(lattice, text)
+
+          tokens = tokenize(text, boundary_constraints)
+          bpos = 0
+          tokens.each do |token|
+            c = token.first
+
+            self.mecab_lattice_set_boundary_constraint(lattice, bpos, MECAB_TOKEN_BOUNDARY)
+            bpos += 1
+
+            mark = token.last ? MECAB_INSIDE_TOKEN : MECAB_ANY_BOUNDARY
+            (c-1).times do
+              self.mecab_lattice_set_boundary_constraint(lattice, bpos, mark)
+              bpos += 1
+            end
+          end
+
+          self.mecab_parse_lattice(@tagger, lattice)
+          
+          if n > 1
+            retval = self.mecab_lattice_nbest_tostr(lattice, n)
+          else
+            retval = self.mecab_lattice_tostr(lattice)
+          end
+          retval.force_encoding(Encoding.default_external)
+        rescue
+          raise(MeCabError.new(self.mecab_lattice_strerror(lattice))) 
+        ensure
+          if lattice.address != 0x0
+            self.mecab_lattice_destroy(lattice)
+          end
+        end
+      }
+        
+      @bcparse_tonodes = ->(text, boundary_constraints=/./) {
+        Enumerator.new do |y|
+          begin
+            lattice = self.mecab_lattice_new()
+            raise MeCabError.new("Could not create Lattice") if lattice.address == 0x0
+
+            if @options[:nbest] && @options[:nbest] > 1
+              n = @options[:nbest]
+              self.mecab_lattice_set_request_type(lattice, MECAB_LATTICE_NBEST)
+            else
+              n = 1
+              self.mecab_lattice_set_request_type(lattice, MECAB_LATTICE_ONE_BEST)
+            end
+
+            self.mecab_lattice_set_sentence(lattice, text)
+
+            tokens = tokenize(text, boundary_constraints)
+            bpos = 0
+            tokens.each do |token|
+              c = token.first
+
+              self.mecab_lattice_set_boundary_constraint(lattice, bpos, MECAB_TOKEN_BOUNDARY)
+              bpos += 1
+
+              mark = token.last ? MECAB_INSIDE_TOKEN : MECAB_ANY_BOUNDARY
+              (c-1).times do
+                self.mecab_lattice_set_boundary_constraint(lattice, bpos, mark)
+                bpos += 1
+              end
+            end
+
+            self.mecab_parse_lattice(@tagger, lattice)
+
+            n.times do
+              check = self.mecab_lattice_next(lattice)
+              if check
+                nptr = self.mecab_lattice_get_bos_node(lattice)
+          
+                s = text.bytes.to_a
+                while nptr && nptr.address!=0x0
+                  mn = Natto::MeCabNode.new(nptr)
                   s = s.drop_while {|e| (e==0xa || e==0x20)}
                   if !s.empty?
                     sarr = []
@@ -224,50 +354,22 @@ module Natto
                     mn.surface = surf.force_encoding(Encoding.default_external)
                   end
                   if @options[:output_format_type] || @options[:node_format]
-                    mn.feature = self.mecab_format_node(@tagger, n).force_encoding(Encoding.default_external)
+                    mn.feature = self.mecab_format_node(@tagger, nptr).force_encoding(Encoding.default_external)
                   end
                   y.yield mn
+                  nptr = mn.next
                 end
-                n = mn.next
               end
-              n = self.mecab_nbest_next_tonode(@tagger)
+            end
+          rescue
+            raise(MeCabError.new(self.mecab_lattice_strerror(lattice))) 
+          ensure
+            if lattice.address != 0x0
+              self.mecab_lattice_destroy(lattice)
             end
           end
-        }
-      else
-        # default parsing implementations
-        @parse_tostr = ->(text) {
-          retval = self.mecab_sparse_tostr(@tagger, text) || 
-                raise(MeCabError.new(self.mecab_strerror(@tagger))) 
-          retval.force_encoding(Encoding.default_external)
-        }
-
-        @parse_tonodes = ->(text) { 
-          Enumerator.new do |y|
-            n = self.mecab_sparse_tonode(@tagger, text) 
-            raise(MeCabError.new(self.mecab_strerror(@tagger))) if n.nil? || n.address==0x0
-          
-            mn = Natto::MeCabNode.new(n)
-            n = mn.next if mn.next.address!=0x0
-            s = text.bytes.to_a
-            while n && n.address!=0x0
-              mn = Natto::MeCabNode.new(n)
-              s = s.drop_while {|e| (e==0xa || e==0x20)}
-              if !s.empty?
-                sarr = []
-                mn.length.times { sarr << s.shift }
-                surf = sarr.pack('C*')
-                mn.surface = surf.force_encoding(Encoding.default_external)
-              end
-              if @options[:output_format_type] || @options[:node_format]
-                mn.feature = self.mecab_format_node(@tagger, n).force_encoding(Encoding.default_external)
-              end
-              y.yield mn
-              n = mn.next
-            end
-          end
-        }
-      end
+        end
+      }
 
       @dicts << Natto::DictionaryInfo.new(Natto::Binding.mecab_dictionary_info(@tagger))
       while @dicts.last.next.address != 0x0
@@ -284,16 +386,25 @@ module Natto
     # and each node yielded to the given block.
     #
     # @param [String] text
+    # @param [Hash] options
     # @return [String] parsing result from `mecab`
     # @raise [MeCabError] if the `mecab` tagger cannot parse the given `text`
     # @raise [ArgumentError] if the given string `text` argument is `nil`
     # @see MeCabNode
-    def parse(text)
+    def parse(text, options={})
       raise ArgumentError.new 'Text to parse cannot be nil' if text.nil?
-      if block_given?
-        @parse_tonodes.call(text).each {|n| yield n }
+      if options[:boundary_constraints]
+        if block_given?
+          @bcparse_tonodes.call(text, options[:boundary_constraints]).each {|n| yield n }
+        else
+          @bcparse_tostr.call(text, options[:boundary_constraints])
+        end
       else
-        @parse_tostr.call(text)
+        if block_given?
+          @parse_tonodes.call(text).each {|n| yield n }
+        else
+          @parse_tostr.call(text)
+        end
       end
     end
 
@@ -301,7 +412,7 @@ module Natto
     # {http://www.ruby-doc.org/core-2.1.5/Enumerator.html Enumerator} that may be
     # used to iterate over the resulting {MeCabNode} objects. This is more 
     # efficient than parsing to a simple string, since each node's
-    # information will not be materialized all at once as with it is with
+    # information will not be materialized all at once as it is with
     # string output.
     #
     # MeCab nodes contain much more detailed information about
@@ -309,65 +420,15 @@ module Natto
     # the resulting node's `feature` attribute.
     #
     # @param [String] text
+    # @param [Hash] options
     # @return [Enumerator] of MeCabNode instances
     # @raise [MeCabError] if the `mecab` tagger cannot parse the given `text`
     # @raise [ArgumentError] if the given string `text` argument is `nil`
     # @see MeCabNode
     # @see http://www.ruby-doc.org/core-2.1.5/Enumerator.html
-    def enum_parse(text)
+    def enum_parse(text, options={})
       raise ArgumentError.new 'Text to parse cannot be nil' if text.nil?
       @parse_tonodes.call(text)
-    end
-
-    # @deprecated
-    # DEPRECATED: use enum_parse instead, this convenience method is useless.
-    # Parses the given string `str`, and returns
-    # a list of `mecab` nodes.
-    # @param [String] str
-    # @return [Array] of parsed `mecab` nodes.
-    # @raise [MeCabError] if the `mecab` tagger cannot parse the given string `str`
-    # @raise [ArgumentError] if the given string `str` argument is `nil`
-    # @see MeCabNode
-    def parse_as_nodes(str)
-      $stderr.puts 'DEPRECATED: use enum_parse instead'
-      $stderr.puts '            This method will be removed in the next release!'
-      raise ArgumentError.new 'String to parse cannot be nil' if str.nil?
-      @parse_tonodes.call(str)
-    end
-
-    # @deprecated
-    # DEPRECATED: use enum_parse instead, this convenience method is useless.
-    # Parses the given string `str`, and returns
-    # a list of `mecab` result strings.
-    # @param [String] str
-    # @return [Array] of parsed `mecab` result strings.
-    # @raise [MeCabError] if the `mecab` tagger cannot parse the given string `str`
-    # @raise [ArgumentError] if the given string `str` argument is `nil`
-    def parse_as_strings(str)
-      $stderr.puts 'DEPRECATED: use enum_parse instead'
-      $stderr.puts '            This method will be removed in the next release!'
-      raise ArgumentError.new 'String to parse cannot be nil' if str.nil?
-      @parse_tostr.call(str).lines.to_a
-    end
-
-    # @deprecated
-    # DEPRECATED: use enum_parse instead, this convenience method is useless.
-    # @param [String] str
-    # @return [Array] of parsed `mecab` nodes.
-    def readnodes(str)
-      $stderr.puts 'DEPRECATED: use enum_parse instead'
-      $stderr.puts '            This method will be removed in the next release!'
-      parse_as_nodes(str)
-    end
-
-    # @deprecated
-    # DEPRECATED: use enum_parse instead, this convenience method is useless.
-    # @param [String] str
-    # @return [Array] of parsed `mecab` result strings.
-    def readlines(str)
-      $stderr.puts 'DEPRECATED: use enum_parse instead'
-      $stderr.puts '            This method will be removed in the next release!'
-      parse_as_strings(str)
     end
 
     # Returns human-readable details for the wrapped `mecab` tagger.
@@ -413,6 +474,29 @@ module Natto
       Proc.new do
         self.mecab_destroy(ptr)
       end
+    end
+
+    private
+
+    def tokenize(text, pattern)
+      matches = text.scan(pattern)
+      
+      acc =[]
+      tmp = text
+      matches.each_with_index do |m,i|
+        bef, mat, aft = tmp.partition(m)
+        unless bef.empty?
+          acc << [bef.bytes.count, false]
+        end
+        unless mat.empty?
+          acc << [mat.bytes.count, true]
+        end
+        if i==matches.size-1 and !aft.empty?
+          acc << [aft.bytes.count, false]
+        end
+        tmp = aft
+      end
+      acc
     end
   end
 

--- a/lib/natto/struct.rb
+++ b/lib/natto/struct.rb
@@ -311,10 +311,7 @@ module Natto
     def is_eon?
       self.stat == EON_NODE
     end
-
-
   end
-
 end
 
 # Copyright (c) 2015, Brooke M. Fujita.

--- a/test/natto/tc_mecab.rb
+++ b/test/natto/tc_mecab.rb
@@ -1,5 +1,6 @@
 # coding: utf-8
 require 'rbconfig'
+require 'yaml'
 
 class TestMeCab < MiniTest::Unit::TestCase
   def setup
@@ -23,6 +24,9 @@ class TestMeCab < MiniTest::Unit::TestCase
       @br       = '\n'
     end
     @test_str = `#{@test_cmd}`
+
+    # boundary constraint parse setup
+    @yml = YAML.load(File.read('test/natto/test_utf8.yml', encoding: Encoding::UTF_8))
   end
 
   def teardown
@@ -269,6 +273,14 @@ class TestMeCab < MiniTest::Unit::TestCase
     assert_equal(expected, actual)
   end
 
+  def test_argument_error
+    [ :parse, :enum_parse ].each do |m|
+      assert_raises ArgumentError do
+        @mn.send(m, nil) 
+      end
+    end
+  end
+
   def test_parse_tostr_default
     expected = `#{@test_cmd} | mecab`.lines.to_a
     expected.delete_if {|e| e =~ /^(EOS|BOS|\t)/ }
@@ -432,12 +444,7 @@ class TestMeCab < MiniTest::Unit::TestCase
     assert_equal(expected[6].strip, enum.next.feature)
   end
 
-  def test_argument_error
-    [ :parse, :enum_parse ].each do |m|
-      assert_raises ArgumentError do
-        @mn.send(m, nil) 
-      end
-    end
+  def test_bcparse_tostr_default
   end
 end 
 

--- a/test/natto/tc_mecab.rb
+++ b/test/natto/tc_mecab.rb
@@ -6,6 +6,7 @@ class TestMeCab < MiniTest::Unit::TestCase
   def setup
     @m = Natto::MeCab.new()
     @m_f = Natto::MeCab.new '-F%pl\t%f[7]...' 
+    @m_s = Natto::MeCab.new '-F%m\s%s'
     @mn = Natto::MeCab.new '-N2' 
     @mn_f = Natto::MeCab.new '-N2 -F%pl\t%f[7]...' 
     @mn_w = Natto::MeCab.new '-N4 -Owakati' 
@@ -23,15 +24,17 @@ class TestMeCab < MiniTest::Unit::TestCase
       @test_cmd = 'cat "test/natto/test_utf8"'
       @br       = '\n'
     end
-    @test_str = `#{@test_cmd}`
+    @test_str   = `#{@test_cmd}`
 
     # boundary constraint parse setup
-    @yml = YAML.load(File.read('test/natto/test_utf8.yml', encoding: Encoding::UTF_8))
+    @yml = YAML.load(File.read('test/natto/test_utf8.yml',
+                               mode: "rb:utf-8:#{Encoding.default_external}"))
   end
 
   def teardown
     @m          = nil
     @m_f        = nil
+    @m_s        = nil
     @mn         = nil
     @mn_f       = nil
     @mn_w       = nil
@@ -41,6 +44,7 @@ class TestMeCab < MiniTest::Unit::TestCase
     @arch       = nil
     @test_cmd   = nil
     @test_str   = nil
+    @yml        = nil
   end
  
   def test_parse_mecab_options
@@ -444,7 +448,82 @@ class TestMeCab < MiniTest::Unit::TestCase
     assert_equal(expected[6].strip, enum.next.feature)
   end
 
-  def test_bcparse_tostr_default
+  def test_bcparse_tostr
+    # simple string pattern
+    test1 = @yml['test1']
+    text  = test1['text']
+    patt  = test1['pattern']
+    expected = test1['expected']
+    actual = @m.parse(text, boundary_constraints: patt).lines.to_a
+    actual.each_with_index do |l,i|
+      assert_match(expected[i], l)
+    end
+
+    # complex Unicode character properties pattern
+    test2 = @yml['test2']
+    text  = test2['text']
+    patt  = test2['pattern']
+    expected = test2['expected']
+    actual = @m.parse(text, boundary_constraints: patt).lines.to_a
+    actual.each_with_index do |l,i|
+      assert_match(expected[i], l)
+    end
+
+    # N-best
+    test3 = @yml['test3']
+    text  = test3['text']
+    patt  = test3['pattern']
+    expected = test3['expected']
+    actual = @mn.parse(text, boundary_constraints: patt).lines.to_a
+    actual.each_with_index do |l,i|
+      assert_match(expected[i], l)
+    end
+  end
+
+  def test_bcparse_tonode
+    # simple string pattern
+    test1 = @yml['test1']
+    text  = test1['text']
+    patt  = test1['pattern']
+    expected = test1['expected']
+    actual = []
+    @m.parse(text, boundary_constraints: patt) {|n| actual << n if !(n.is_bos? || n.is_eos?)}    
+    actual.each_with_index do |l,i|
+      assert_match(expected[i], l.surface)
+    end
+
+    # complex Unicode character properties pattern
+    test2 = @yml['test2']
+    text  = test2['text']
+    patt  = test2['pattern']
+    expected = test2['expected']
+    actual = []
+    @m.parse(text, boundary_constraints: patt) {|n| actual << n if !(n.is_bos? || n.is_eos?)}    
+    actual.each_with_index do |l,i|
+      assert_match(expected[i], l.surface)
+    end
+    
+    # N-best
+    test3 = @yml['test3']
+    text  = test3['text']
+    patt  = test3['pattern']
+    expected = test3['expected']
+    actual = []
+    @m.parse(text, boundary_constraints: patt) {|n| actual << n if !(n.is_bos? || n.is_eos?)}    
+    actual.each_with_index do |l,i|
+      assert_match(expected[i], l.feature)
+    end
+    
+    # w/ output formatting
+    test4 = @yml['test4']
+    text  = test4['text']
+    patt  = test4['pattern']
+    expected = test4['expected']
+    actual = []
+    @m_s.parse(text, boundary_constraints: patt) {|n| actual << n if !(n.is_bos? || n.is_eos?)}    
+    actual.each_with_index do |l,i|
+      assert_equal(expected[i], l.feature)
+    end
   end
 end 
 

--- a/test/natto/test_utf8.yml
+++ b/test/natto/test_utf8.yml
@@ -1,6 +1,6 @@
-text1:
+test1:
     text: にわにはにわにわとりがいる。
-    pattern: にわとり|にわ|はにわ
+    pattern: !ruby/regexp '/にわとり|にわ|はにわ/'
     expected: 
         - にわ
         - に
@@ -10,33 +10,15 @@ text1:
         - いる
         - 。
         - EOS
-text2:
-    text: 123 ABCは１つの形態素として扱う。
-    pattern: '[\d]{2,}[\s]+[A-Z]{2,3}'
-    expected:
-        - 123 ABC
-        - は
-        - １つ
-        - の
-        - 形態素
-        - として
-        - 扱う
-        - 。
+test2:
+    text: 123 ABCおよび１２３　ＡＢＣ
+    pattern: !ruby/regexp '/\p{Number}{3}\p{Space}+\p{Alphabetic}{3}/'
+    expected: 
+        - 123 ABC 
+        - および
+        - １２３　ＡＢＣ
         - EOS
-text3:
-    text: １２３　ABCは１つの形態素として扱う。
-    pattern: '[\d]{2,}[\s]+[A-Z]{2,3}'
-    expected:
-        - １２３　ABC
-        - は
-        - １つ
-        - の
-        - 形態素
-        - として
-        - 扱う
-        - 。
-        - EOS
-text4:
+test3:
     text: 初心
     pattern: 初心
     expected:
@@ -44,9 +26,9 @@ text4:
         - EOS
         - ウブ 
         - EOS
-text5:
+test4:
     text: にわにはにわにわとりがいる。
-    pattern: にわとり|にわ|はにわ
+    pattern: !ruby/regexp '/にわとり|にわ|はにわ/'
     expected: 
         - にわ 1
         - に 0
@@ -55,44 +37,3 @@ text5:
         - が 0
         - いる 0
         - 。 0
-text6:
-    text: にわにはにわにわとりがいる。
-    pattern: にわとり|にわ|はにわ
-    expected: 
-        - にわ 名詞 一般 1 
-        - に 助詞 格助詞 0
-        - はにわ 名詞 一般 0
-        - にわとり 名詞 一般 0
-        - が 助詞 格助詞 0
-        - いる 動詞 自立 0
-        - 。 記号 句点 0
-        - にわ 名詞 固有名詞 1 
-        - に 助詞 格助詞 0
-        - はにわ 名詞 一般 0
-        - にわとり 名詞 一般 0
-        - が 助詞 格助詞 0
-        - いる 動詞 自立 0
-        - 。 記号 句点 0
-text7:
-    text: 123 ABCおよび１２３　ＡＢＣ
-    pattern: '[\d]{3}[\s]+[A-ZＡ-Ｚ]{3}'
-    tokens: 
-        - 123 ABC 
-        - および
-        - １２３　ＡＢＣ
-    matches:
-        - True
-        - False
-        - True
-text8:
-    text: 123 ABCおよび１２３　ＡＢＣ
-    pattern: '[\d]{3}[\s]+[A-ZＡ-Ｚ]{3}'
-    
-    tokens: 
-        - 123 ABC 
-        - および
-        - １２３　ＡＢＣ
-    matches:
-        - True
-        - False
-        - True

--- a/test/natto/test_utf8.yml
+++ b/test/natto/test_utf8.yml
@@ -76,40 +76,23 @@ text6:
 text7:
     text: 123 ABCおよび１２３　ＡＢＣ
     pattern: '[\d]{3}[\s]+[A-ZＡ-Ｚ]{3}'
-    py2:
-        tokens: 
-            - 123 ABC 
-            - および１２３　ＡＢＣ
-        matches:
-            - True
-            - False
-    py3:
-        tokens: 
-            - 123 ABC 
-            - および
-            - １２３　ＡＢＣ
-        matches:
-            - True
-            - False
-            - True
+    tokens: 
+        - 123 ABC 
+        - および
+        - １２３　ＡＢＣ
+    matches:
+        - True
+        - False
+        - True
 text8:
     text: 123 ABCおよび１２３　ＡＢＣ
     pattern: '[\d]{3}[\s]+[A-ZＡ-Ｚ]{3}'
-    py2:
-        tokens: 
-            - 123 ABC 
-            - および
-            - １２３　ＡＢＣ
-        matches:
-            - True
-            - False
-            - True
-    py3:
-        tokens: 
-            - 123 ABC 
-            - および
-            - １２３　ＡＢＣ
-        matches:
-            - True
-            - False
-            - True
+    
+    tokens: 
+        - 123 ABC 
+        - および
+        - １２３　ＡＢＣ
+    matches:
+        - True
+        - False
+        - True

--- a/test/natto/test_utf8.yml
+++ b/test/natto/test_utf8.yml
@@ -1,0 +1,115 @@
+text1:
+    text: にわにはにわにわとりがいる。
+    pattern: にわとり|にわ|はにわ
+    expected: 
+        - にわ
+        - に
+        - はにわ
+        - にわとり
+        - が
+        - いる
+        - 。
+        - EOS
+text2:
+    text: 123 ABCは１つの形態素として扱う。
+    pattern: '[\d]{2,}[\s]+[A-Z]{2,3}'
+    expected:
+        - 123 ABC
+        - は
+        - １つ
+        - の
+        - 形態素
+        - として
+        - 扱う
+        - 。
+        - EOS
+text3:
+    text: １２３　ABCは１つの形態素として扱う。
+    pattern: '[\d]{2,}[\s]+[A-Z]{2,3}'
+    expected:
+        - １２３　ABC
+        - は
+        - １つ
+        - の
+        - 形態素
+        - として
+        - 扱う
+        - 。
+        - EOS
+text4:
+    text: 初心
+    pattern: 初心
+    expected:
+        - ショシン 
+        - EOS
+        - ウブ 
+        - EOS
+text5:
+    text: にわにはにわにわとりがいる。
+    pattern: にわとり|にわ|はにわ
+    expected: 
+        - にわ 1
+        - に 0
+        - はにわ 0
+        - にわとり 0
+        - が 0
+        - いる 0
+        - 。 0
+text6:
+    text: にわにはにわにわとりがいる。
+    pattern: にわとり|にわ|はにわ
+    expected: 
+        - にわ 名詞 一般 1 
+        - に 助詞 格助詞 0
+        - はにわ 名詞 一般 0
+        - にわとり 名詞 一般 0
+        - が 助詞 格助詞 0
+        - いる 動詞 自立 0
+        - 。 記号 句点 0
+        - にわ 名詞 固有名詞 1 
+        - に 助詞 格助詞 0
+        - はにわ 名詞 一般 0
+        - にわとり 名詞 一般 0
+        - が 助詞 格助詞 0
+        - いる 動詞 自立 0
+        - 。 記号 句点 0
+text7:
+    text: 123 ABCおよび１２３　ＡＢＣ
+    pattern: '[\d]{3}[\s]+[A-ZＡ-Ｚ]{3}'
+    py2:
+        tokens: 
+            - 123 ABC 
+            - および１２３　ＡＢＣ
+        matches:
+            - True
+            - False
+    py3:
+        tokens: 
+            - 123 ABC 
+            - および
+            - １２３　ＡＢＣ
+        matches:
+            - True
+            - False
+            - True
+text8:
+    text: 123 ABCおよび１２３　ＡＢＣ
+    pattern: '[\d]{3}[\s]+[A-ZＡ-Ｚ]{3}'
+    py2:
+        tokens: 
+            - 123 ABC 
+            - および
+            - １２３　ＡＢＣ
+        matches:
+            - True
+            - False
+            - True
+    py3:
+        tokens: 
+            - 123 ABC 
+            - および
+            - １２３　ＡＢＣ
+        matches:
+            - True
+            - False
+            - True


### PR DESCRIPTION
Adding unit tests for boundary constraint parsing to cover tostr and tonode parsing, with N-best and output formatting.

Also removing deprecated methods.