### PR TITLE
Enhancements to tokenization for boundary constraint parsing 

### DIFF
--- a/lib/natto/binding.rb
+++ b/lib/natto/binding.rb
@@ -93,6 +93,8 @@ module Natto
     attach_function :mecab_lattice_set_z, [:pointer, :float], :void
     attach_function :mecab_lattice_set_theta, [:pointer, :float], :void
     attach_function :mecab_lattice_next, [:pointer], :int
+    attach_function :mecab_lattice_get_request_type, [:pointer], :int
+    attach_function :mecab_lattice_add_request_type, [:pointer, :int], :void
     attach_function :mecab_lattice_set_request_type, [:pointer, :int], :void
     attach_function :mecab_lattice_tostr, [:pointer], :string
     attach_function :mecab_lattice_nbest_tostr, [:pointer, :int], :string
@@ -213,6 +215,14 @@ module Natto
         Natto::Binding.mecab_lattice_next(lptr)
       end
  
+      def mecab_lattice_get_request_type(lptr)
+        Natto::Binding.mecab_lattice_get_request_type(lptr)
+      end
+      
+      def mecab_lattice_add_request_type(lptr, rtype)
+        Natto::Binding.mecab_lattice_add_request_type(lptr, rtype)
+      end
+
       def mecab_lattice_set_request_type(lptr, rtype)
         Natto::Binding.mecab_lattice_set_request_type(lptr, rtype)
       end

--- a/lib/natto/natto.rb
+++ b/lib/natto/natto.rb
@@ -276,12 +276,13 @@ module Natto
             self.mecab_lattice_set_theta(lattice, @options[:theta])
           end
 
+          tokens = tokenize(text, boundary_constraints)
+          text = tokens.map {|t| t.first}.join
           self.mecab_lattice_set_sentence(lattice, text)
 
-          tokens = tokenize(text, boundary_constraints)
           bpos = 0
           tokens.each do |token|
-            c = token.first
+            c = token.first.bytes.count
 
             self.mecab_lattice_set_boundary_constraint(lattice, bpos, MECAB_TOKEN_BOUNDARY)
             bpos += 1
@@ -327,12 +328,13 @@ module Natto
               self.mecab_lattice_set_theta(lattice, @options[:theta])
             end
 
+            tokens = tokenize(text, boundary_constraints)
+            text = tokens.map {|t| t.first}.join
             self.mecab_lattice_set_sentence(lattice, text)
 
-            tokens = tokenize(text, boundary_constraints)
             bpos = 0
             tokens.each do |token|
-              c = token.first
+              c = token.first.bytes.count
 
               self.mecab_lattice_set_boundary_constraint(lattice, bpos, MECAB_TOKEN_BOUNDARY)
               bpos += 1
@@ -511,13 +513,13 @@ module Natto
       matches.each_with_index do |m,i|
         bef, mat, aft = tmp.partition(m)
         unless bef.empty?
-          acc << [bef.bytes.count, false]
+          acc << [bef.strip, false]
         end
         unless mat.empty?
-          acc << [mat.bytes.count, true]
+          acc << [mat.strip, true]
         end
         if i==matches.size-1 and !aft.empty?
-          acc << [aft.bytes.count, false]
+          acc << [aft.strip, false]
         end
         tmp = aft
       end

--- a/test/natto/tc_binding.rb
+++ b/test/natto/tc_binding.rb
@@ -45,6 +45,8 @@ class TestNattoBinding < MiniTest::Unit::TestCase
        :mecab_lattice_set_z,
        :mecab_lattice_set_theta,
        :mecab_lattice_next,
+       :mecab_lattice_get_request_type,
+       :mecab_lattice_add_request_type,
        :mecab_lattice_set_request_type,
        :mecab_lattice_tostr,
        :mecab_lattice_nbest_tostr,

--- a/test/natto/tc_mecab.rb
+++ b/test/natto/tc_mecab.rb
@@ -31,10 +31,9 @@ class TestMeCab < MiniTest::Unit::TestCase
     # boundary constraint parse setup
     yml = YAML.load(File.read('test/natto/test_utf8.yml'))
     @yml1 = { text: yml['test1']['text'].encode(Encoding.default_external),
-              pattern: yml['test1']['pattern'].encode(Encoding.default_external),
               expected: yml['test1']['expected'].map {|e| e.encode(Encoding.default_external)} }
     @yml2 = { text: yml['test2']['text'].encode(Encoding.default_external),
-              pattern: yml['test2']['pattern'].encode(Encoding.default_external),
+              options: yml['test2']['options'].encode(Encoding.default_external),
               expected: yml['test2']['expected'].map {|e| e.encode(Encoding.default_external)} }
     @yml3 = { text: yml['test3']['text'].encode(Encoding.default_external),
               pattern: yml['test3']['pattern'].encode(Encoding.default_external),
@@ -43,10 +42,14 @@ class TestMeCab < MiniTest::Unit::TestCase
               pattern: yml['test4']['pattern'].encode(Encoding.default_external),
               expected: yml['test4']['expected'].map {|e| e.encode(Encoding.default_external)} }
     @yml5 = { text: yml['test5']['text'].encode(Encoding.default_external),
+              pattern: yml['test5']['pattern'].encode(Encoding.default_external),
               expected: yml['test5']['expected'].map {|e| e.encode(Encoding.default_external)} }
     @yml6 = { text: yml['test6']['text'].encode(Encoding.default_external),
-              options: yml['test6']['options'].encode(Encoding.default_external),
+              pattern: yml['test6']['pattern'].encode(Encoding.default_external),
               expected: yml['test6']['expected'].map {|e| e.encode(Encoding.default_external)} }
+    @yml7 = { text: yml['test7']['text'].encode(Encoding.default_external),
+              pattern: yml['test7']['pattern'].encode(Encoding.default_external),
+              expected: yml['test7']['expected'].map {|e| e.encode(Encoding.default_external)} }
   end
 
   def teardown
@@ -68,6 +71,9 @@ class TestMeCab < MiniTest::Unit::TestCase
     @yml2       = nil
     @yml3       = nil
     @yml4       = nil
+    @yml5       = nil
+    @yml6       = nil
+    @yml7       = nil
   end
  
   def test_parse_mecab_options
@@ -496,8 +502,8 @@ class TestMeCab < MiniTest::Unit::TestCase
   end
 
   def test_parse_tostr_partial
-    text  = @yml5[:text]
-    expected = @yml5[:expected]
+    text  = @yml1[:text]
+    expected = @yml1[:expected]
     actual = @m_p.parse(text).lines.to_a
     actual.each_with_index do |l,i|
       assert_match(expected[i], l)
@@ -505,9 +511,9 @@ class TestMeCab < MiniTest::Unit::TestCase
   end
 
   def test_parse_tonode_partial_output_formatting
-    text  = @yml6[:text]
-    options = @yml6[:options]
-    expected = @yml6[:expected]
+    text  = @yml2[:text]
+    options = @yml2[:options]
+    expected = @yml2[:expected]
     nm = Natto::MeCab.new(options)
     actual = []
     nm.parse(text) {|n| actual << n.feature if !(n.is_bos? || n.is_eos?)}    
@@ -518,27 +524,27 @@ class TestMeCab < MiniTest::Unit::TestCase
 
   def test_bcparse_tostr
     # simple string pattern
-    text  = @yml1[:text]
-    patt  = @yml1[:pattern]
-    expected = @yml1[:expected]
+    text  = @yml3[:text]
+    patt  = @yml3[:pattern]
+    expected = @yml3[:expected]
     actual = @m.parse(text, boundary_constraints: Regexp.new(patt)).lines.to_a
     actual.each_with_index do |l,i|
       assert_match(expected[i], l)
     end
 
     # complex Unicode character properties pattern
-    text  = @yml2[:text]
-    patt  = @yml2[:pattern]
-    expected = @yml2[:expected]
+    text  = @yml4[:text]
+    patt  = @yml4[:pattern]
+    expected = @yml4[:expected]
     actual = @m.parse(text, boundary_constraints: Regexp.new(patt)).lines.to_a
     actual.each_with_index do |l,i|
       assert_match(expected[i], l)
     end
 
     # N-best
-    text  = @yml3[:text]
-    patt  = @yml3[:pattern]
-    expected = @yml3[:expected]
+    text  = @yml5[:text]
+    patt  = @yml5[:pattern]
+    expected = @yml5[:expected]
     actual = @mn.parse(text, boundary_constraints: Regexp.new(patt)).lines.to_a
     actual.each_with_index do |l,i|
       assert_match(expected[i], l)
@@ -547,9 +553,9 @@ class TestMeCab < MiniTest::Unit::TestCase
 
   def test_bcparse_tonode
     # simple string pattern
-    text  = @yml1[:text]
-    patt  = @yml1[:pattern]
-    expected = @yml1[:expected]
+    text  = @yml3[:text]
+    patt  = @yml3[:pattern]
+    expected = @yml3[:expected]
     actual = []
     @m.parse(text, boundary_constraints: Regexp.new(patt)) {|n| actual << n if !(n.is_bos? || n.is_eos?)}    
     actual.each_with_index do |l,i|
@@ -557,9 +563,9 @@ class TestMeCab < MiniTest::Unit::TestCase
     end
 
     # complex Unicode character properties pattern
-    text  = @yml2[:text]
-    patt  = @yml2[:pattern]
-    expected = @yml2[:expected]
+    text  = @yml4[:text]
+    patt  = @yml4[:pattern]
+    expected = @yml4[:expected]
     actual = []
     @m.parse(text, boundary_constraints: Regexp.new(patt)) {|n| actual << n if !(n.is_bos? || n.is_eos?)}    
     actual.each_with_index do |l,i|
@@ -567,9 +573,9 @@ class TestMeCab < MiniTest::Unit::TestCase
     end
     
     # N-best
-    text  = @yml3[:text]
-    patt  = @yml3[:pattern]
-    expected = @yml3[:expected]
+    text  = @yml5[:text]
+    patt  = @yml5[:pattern]
+    expected = @yml5[:expected]
     actual = []
     @m.parse(text, boundary_constraints: Regexp.new(patt)) {|n| actual << n if !(n.is_bos? || n.is_eos?)}    
     actual.each_with_index do |l,i|
@@ -577,9 +583,9 @@ class TestMeCab < MiniTest::Unit::TestCase
     end
     
     # w/ output formatting
-    text  = @yml4[:text]
-    patt  = @yml4[:pattern]
-    expected = @yml4[:expected]
+    text  = @yml6[:text]
+    patt  = @yml6[:pattern]
+    expected = @yml6[:expected]
     actual = []
     @m_s.parse(text, boundary_constraints: Regexp.new(patt)) {|n| actual << n if !(n.is_bos? || n.is_eos?)}    
     actual.each_with_index do |l,i|
@@ -587,11 +593,32 @@ class TestMeCab < MiniTest::Unit::TestCase
     end
   end
   
+  def test_bcparse_tostr_whitespace_included
+    text  = @yml7[:text]
+    patt  = @yml7[:pattern]
+    expected = @yml7[:expected]
+    actual = @m.parse(text, boundary_constraints: Regexp.new(patt)).lines.to_a
+    actual.each_with_index do |l,i|
+      assert_match(expected[i], l)
+    end
+  end
+
+  def test_bcparse_tonode_whitespace_included
+    text  = @yml7[:text]
+    patt  = @yml7[:pattern]
+    expected = @yml7[:expected]
+    actual = []
+    @m_t.parse(text, boundary_constraints: Regexp.new(patt)) {|n| actual << n if !(n.is_bos? || n.is_eos?)}    
+    actual.each_with_index do |l,i|
+      assert_match(expected[i], l.surface)
+    end
+  end
+
   def test_bcparse_tostr_theta
     # simple string pattern
-    text  = @yml1[:text]
-    patt  = @yml1[:pattern]
-    expected = @yml1[:expected]
+    text  = @yml3[:text]
+    patt  = @yml3[:pattern]
+    expected = @yml3[:expected]
     actual = @m_t.parse(text, boundary_constraints: Regexp.new(patt)).lines.to_a
     actual.each_with_index do |l,i|
       assert_match(expected[i], l)
@@ -600,9 +627,9 @@ class TestMeCab < MiniTest::Unit::TestCase
 
   def test_bcparse_tonode_theta
     # simple string pattern
-    text  = @yml1[:text]
-    patt  = @yml1[:pattern]
-    expected = @yml1[:expected]
+    text  = @yml3[:text]
+    patt  = @yml3[:pattern]
+    expected = @yml3[:expected]
     actual = []
     @m_t.parse(text, boundary_constraints: Regexp.new(patt)) {|n| actual << n if !(n.is_bos? || n.is_eos?)}    
     actual.each_with_index do |l,i|

--- a/test/natto/test_utf8.yml
+++ b/test/natto/test_utf8.yml
@@ -1,4 +1,24 @@
 test1:
+    text: "では\nブルザエモン\tその他\nは何者だ？"
+    expected: 
+        - では
+        - ブルザエモン
+        - は
+        - 何者
+        - だ
+        - ？
+        - EOS
+test2:
+    text: "では\nブルザエモン\tその他\nは何者だ？"
+    options: '-p -F%m,%F,[0]'
+    expected: 
+        - では,接続詞
+        - ブルザエモン,その他 
+        - は,助詞 
+        - 何者,名詞
+        - だ,助動詞 
+        - ？,記号 
+test3:
     text: にわにはにわにわとりがいる。
     pattern: 'にわとり|にわ|はにわ'
     expected: 
@@ -10,7 +30,7 @@ test1:
         - いる
         - 。
         - EOS
-test2:
+test4:
     text: 123 ABCおよび１２３　ＡＢＣ
     pattern: '\p{Number}{3}\p{Space}+\p{Alphabetic}{3}'
     expected: 
@@ -18,7 +38,7 @@ test2:
         - および
         - １２３　ＡＢＣ
         - EOS
-test3:
+test5:
     text: 初心
     pattern: 初心
     expected:
@@ -26,7 +46,7 @@ test3:
         - EOS
         - ウブ 
         - EOS
-test4:
+test6:
     text: にわにはにわにわとりがいる。
     pattern: 'にわとり|にわ|はにわ'
     expected: 
@@ -37,23 +57,22 @@ test4:
         - が 0
         - いる 0
         - 。 0
-test5:
-    text: "では\nブルザエモン\tその他\nは何者だ？"
+test7:
+    text: 心の中で3回唱え、 ヒーロー見参！ヒーロー見参！ヒーロー見参！ 
+    pattern: ヒーロー見参
     expected: 
-        - では
-        - ブルザエモン
-        - は
-        - 何者
-        - だ
-        - ？
+        - 心
+        - の
+        - 中
+        - で
+        - '3'
+        - 回
+        - 唱え
+        - 、
+        - ヒーロー見参
+        - ！
+        - ヒーロー見参
+        - ！
+        - ヒーロー見参
+        - ！
         - EOS
-test6:
-    text: "では\nブルザエモン\tその他\nは何者だ？"
-    options: '-p -F%m,%F,[0]'
-    expected: 
-        - では,接続詞
-        - ブルザエモン,その他 
-        - は,助詞 
-        - 何者,名詞
-        - だ,助動詞 
-        - ？,記号 


### PR DESCRIPTION
Fixes for behavior for handling tokenization when whitespace chars are at the start or end of tokens in boundary constraint parsing.