### PR TITLE
Support for marginal probability output during node parsing

### DIFF
--- a/lib/natto/natto.rb
+++ b/lib/natto/natto.rb
@@ -354,6 +354,9 @@ module Natto
             if @options[:theta]
               self.mecab_lattice_set_theta(lattice, @options[:theta])
             end
+            if @options[:marginal]
+              self.mecab_lattice_add_request_type(lattice, MECAB_LATTICE_MARGINAL_PROB)
+            end
 
             tokens = tokenize(text, boundary_constraints)
             text = tokens.map {|t| t.first}.join

--- a/lib/natto/option_parse.rb
+++ b/lib/natto/option_parse.rb
@@ -103,7 +103,7 @@ module Natto
         SUPPORTED_OPTS.values.each do |k|
           if options.has_key? k
             key = k.to_s.gsub('_', '-')  
-            if %w( all-morphs allocate-sentence partial ).include? key
+            if [ :all_morphs, :partial, :marginal, :allocate_sentence ].include?(k) 
               opt << "--#{key}" if options[k]==true
             else
               opt << "--#{key}=#{options[k]}"

--- a/test/natto/tc_mecab.rb
+++ b/test/natto/tc_mecab.rb
@@ -9,6 +9,7 @@ class TestMeCab < MiniTest::Unit::TestCase
     @m_s = Natto::MeCab.new '-F%m\s%s'
     @m_t = Natto::MeCab.new '-t 0.666'
     @m_p = Natto::MeCab.new '-p'
+    @m_m = Natto::MeCab.new '-m -t 0.001'
     @mn = Natto::MeCab.new '-N2' 
     @mn_f = Natto::MeCab.new '-N2 -F%pl\t%f[7]...' 
     @mn_w = Natto::MeCab.new '-N4 -Owakati' 
@@ -58,6 +59,7 @@ class TestMeCab < MiniTest::Unit::TestCase
     @m_s        = nil
     @m_t        = nil
     @m_p        = nil
+    @m_m        = nil
     @mn         = nil
     @mn_f       = nil
     @mn_w       = nil
@@ -467,6 +469,24 @@ class TestMeCab < MiniTest::Unit::TestCase
     end
 
     assert_equal(expected, actual)
+  end
+
+  def test_parse_tonode_marginal
+    @m_t.parse(@test_str) do |n|
+      if !(n.is_eos? or n.is_bos?)
+        assert(n.prob == 0.0)
+        assert(n.alpha == 0.0)
+        assert(n.beta == 0.0)
+      end
+    end
+
+    @m_m.parse(@test_str) do |n|
+      if !(n.is_eos? or n.is_bos?)
+        assert(n.prob != 0.0)
+        assert(n.alpha != 0.0)
+        assert(n.beta != 0.0)
+      end
+    end
   end
 
   def test_enum_parse_default

--- a/test/natto/tc_option_parse.rb
+++ b/test/natto/tc_option_parse.rb
@@ -22,56 +22,56 @@ class TestOptionParse < MiniTest::Unit::TestCase
       '-r/some/file',
       '--rcfile=/some/file',
       '--rcfile /some/file',
-      {:rcfile=>"/some/file"} ].each do |opts|
-      assert_equal({:rcfile => '/some/file'}, @klass.parse_mecab_options(opts))
+      {rcfile: "/some/file"} ].each do |opts|
+      assert_equal({rcfile: '/some/file'}, @klass.parse_mecab_options(opts))
     end
 
     [ '-d /some/other/file',
       '-d/some/other/file',
       '--dicdir=/some/other/file',
       '--dicdir /some/other/file',
-      {:dicdir=>"/some/other/file"} ].each do |opts|
-      assert_equal({:dicdir => '/some/other/file'}, @klass.parse_mecab_options(opts))
+      {dicdir: "/some/other/file"} ].each do |opts|
+      assert_equal({dicdir: '/some/other/file'}, @klass.parse_mecab_options(opts))
     end
    
     [ '-u /yet/another/file',
       '-u/yet/another/file',
       '--userdic=/yet/another/file',
       '--userdic /yet/another/file',
-      {:userdic=>"/yet/another/file"} ].each do |opts|
-      assert_equal({:userdic => '/yet/another/file'}, @klass.parse_mecab_options(opts))
+      {userdic: "/yet/another/file"} ].each do |opts|
+      assert_equal({userdic: '/yet/another/file'}, @klass.parse_mecab_options(opts))
     end
    
     [ '-l 42',
       '-l42',
       '--lattice-level=42',
       '--lattice-level 42',
-      {:lattice_level=>42}
+      {lattice_level: 42}
     ].each do |opts|
-      assert_equal({:lattice_level => 42}, @klass.parse_mecab_options(opts))
+      assert_equal({lattice_level: 42}, @klass.parse_mecab_options(opts))
     end
    
     [ '-a',
       '--all-morphs',
-      {:all_morphs=>true} ].each do |opts|
-      assert_equal({:all_morphs => true}, @klass.parse_mecab_options(opts))
+      {all_morphs: true} ].each do |opts|
+      assert_equal({all_morphs: true}, @klass.parse_mecab_options(opts))
     end
    
     [ '-O natto',
       '-Onatto',
       '--output-format-type=natto',
       '--output-format-type natto',
-      {:output_format_type=>"natto"} ].each do |opts|
-      assert_equal({:output_format_type => 'natto'}, @klass.parse_mecab_options(opts))
+      {output_format_type: "natto"} ].each do |opts|
+      assert_equal({output_format_type: 'natto'}, @klass.parse_mecab_options(opts))
     end
    
     [ '-N 42',
       '-N42',
       '--nbest=42',
       '--nbest 42',
-      {:nbest=>42}
+      {nbest: 42}
     ].each do |opts|
-      assert_equal({:nbest => 42}, @klass.parse_mecab_options(opts))
+      assert_equal({nbest: 42}, @klass.parse_mecab_options(opts))
     end
     [ '--nbest=-1', '--nbest=0', '--nbest=513' ].each do |bad|
       assert_raises Natto::MeCabError do
@@ -81,105 +81,105 @@ class TestOptionParse < MiniTest::Unit::TestCase
    
     [ '-p',
       '--partial',
-      {:partial=>true} ].each do |opts|
-      assert_equal({:partial => true}, @klass.parse_mecab_options(opts))
+      {partial: true} ].each do |opts|
+      assert_equal({partial: true}, @klass.parse_mecab_options(opts))
     end
    
     [ '-m',
       '--marginal',
-      {:marginal=>true} ].each do |opts|
-      assert_equal({:marginal => true}, @klass.parse_mecab_options(opts))
+      {marginal: true} ].each do |opts|
+      assert_equal({marginal: true}, @klass.parse_mecab_options(opts))
     end
    
     [ '-M 42',
       '-M42',
       '--max-grouping-size=42',
       '--max-grouping-size 42',
-      {:max_grouping_size=>42}
+      {max_grouping_size: 42}
     ].each do |opts|
-      assert_equal({:max_grouping_size => 42}, @klass.parse_mecab_options(opts))
+      assert_equal({max_grouping_size: 42}, @klass.parse_mecab_options(opts))
     end
     
     [ '-F %m\t%f[7]\n',
       '-F%m\t%f[7]\n',
       '--node-format=%m\t%f[7]\n',
       '--node-format %m\t%f[7]\n',
-      {:node_format=>'%m\t%f[7]\n'} ].each do |opts|
-      assert_equal({:node_format => '%m\t%f[7]\n'}, @klass.parse_mecab_options(opts))
+      {node_format: '%m\t%f[7]\n'} ].each do |opts|
+      assert_equal({node_format: '%m\t%f[7]\n'}, @klass.parse_mecab_options(opts))
     end
 
     [ '-U %m\t%f[7]\n',
       '-U%m\t%f[7]\n',
       '--unk-format=%m\t%f[7]\n',
       '--unk-format %m\t%f[7]\n',
-      {:unk_format=>'%m\t%f[7]\n'} ].each do |opts|
-      assert_equal({:unk_format => '%m\t%f[7]\n'}, @klass.parse_mecab_options(opts))
+      {unk_format: '%m\t%f[7]\n'} ].each do |opts|
+      assert_equal({unk_format: '%m\t%f[7]\n'}, @klass.parse_mecab_options(opts))
     end
     
     [ '-B %m\t%f[7]\n',
       '-B%m\t%f[7]\n',
       '--bos-format=%m\t%f[7]\n',
       '--bos-format %m\t%f[7]\n',
-      {:bos_format=>'%m\t%f[7]\n'} ].each do |opts|
-      assert_equal({:bos_format => '%m\t%f[7]\n'}, @klass.parse_mecab_options(opts))
+      {bos_format: '%m\t%f[7]\n'} ].each do |opts|
+      assert_equal({bos_format: '%m\t%f[7]\n'}, @klass.parse_mecab_options(opts))
     end
     
     [ '-E %m\t%f[7]\n',
       '-E%m\t%f[7]\n',
       '--eos-format=%m\t%f[7]\n',
       '--eos-format %m\t%f[7]\n',
-      {:eos_format=>'%m\t%f[7]\n'} ].each do |opts|
-      assert_equal({:eos_format => '%m\t%f[7]\n'}, @klass.parse_mecab_options(opts))
+      {eos_format: '%m\t%f[7]\n'} ].each do |opts|
+      assert_equal({eos_format: '%m\t%f[7]\n'}, @klass.parse_mecab_options(opts))
     end
     
     [ '-S %m\t%f[7]\n',
       '-S%m\t%f[7]\n',
       '--eon-format=%m\t%f[7]\n',
       '--eon-format %m\t%f[7]\n',
-      {:eon_format=>'%m\t%f[7]\n'} ].each do |opts|
-      assert_equal({:eon_format => '%m\t%f[7]\n'}, @klass.parse_mecab_options(opts))
+      {eon_format: '%m\t%f[7]\n'} ].each do |opts|
+      assert_equal({eon_format: '%m\t%f[7]\n'}, @klass.parse_mecab_options(opts))
     end
     
     [ '-x %m\t%f[7]\n',
       '-x%m\t%f[7]\n',
       '--unk-feature=%m\t%f[7]\n',
       '--unk-feature %m\t%f[7]\n',
-      {:unk_feature=>'%m\t%f[7]\n'} ].each do |opts|
-      assert_equal({:unk_feature => '%m\t%f[7]\n'}, @klass.parse_mecab_options(opts))
+      {unk_feature: '%m\t%f[7]\n'} ].each do |opts|
+      assert_equal({unk_feature: '%m\t%f[7]\n'}, @klass.parse_mecab_options(opts))
     end
     
     [ '-b 102400',
       '-b102400',
       '--input-buffer-size=102400',
       '--input-buffer-size 102400',
-      {:input_buffer_size=>102400} ].each do |opts|
-      assert_equal({:input_buffer_size => 102400}, @klass.parse_mecab_options(opts))
+      {input_buffer_size: 102400} ].each do |opts|
+      assert_equal({input_buffer_size: 102400}, @klass.parse_mecab_options(opts))
     end
     
     [ '-C',
       '--allocate-sentence',
-      {:allocate_sentence=>true} ].each do |opts|
-      assert_equal({:allocate_sentence => true}, @klass.parse_mecab_options(opts))
+      {allocate_sentence: true} ].each do |opts|
+      assert_equal({allocate_sentence: true}, @klass.parse_mecab_options(opts))
     end
     
     [ '-t 0.42',
       '-t0.42',
       '--theta=0.42',
       '--theta 0.42',
-      {:theta=>0.42} ].each do |opts|
-      assert_equal({:theta => 0.42}, @klass.parse_mecab_options(opts))
+      {theta: 0.42} ].each do |opts|
+      assert_equal({theta: 0.42}, @klass.parse_mecab_options(opts))
     end
     
     [ '-c 42',
       '-c42',
       '--cost-factor=42',
       '--cost-factor 42',
-      {:cost_factor=>42} ].each do |opts|
-      assert_equal({:cost_factor => 42}, @klass.parse_mecab_options(opts))
+      {cost_factor: 42} ].each do |opts|
+      assert_equal({cost_factor: 42}, @klass.parse_mecab_options(opts))
     end
 
     assert_equal({}, @klass.parse_mecab_options)
-    assert_equal({}, @klass.parse_mecab_options(:unknown=>"ignore"))
+    assert_equal({}, @klass.parse_mecab_options(unknown: "ignore"))
   end
 
   def test_build_options_str
@@ -191,6 +191,7 @@ class TestOptionParse < MiniTest::Unit::TestCase
     assert_equal('--all-morphs', @klass.build_options_str(all_morphs: true))
     assert_equal('--nbest=42', @klass.build_options_str(nbest: 42))
     assert_equal('--partial', @klass.build_options_str(partial: true))
+    assert_equal('--marginal', @klass.build_options_str(marginal: true))
     assert_equal('--node-format=%m\t%f[7]\n', @klass.build_options_str(node_format: '%m\t%f[7]\n'))
     assert_equal('--unk-format=%m\t%f[7]\n', @klass.build_options_str(unk_format: '%m\t%f[7]\n'))
     assert_equal('--bos-format=%m\t%f[7]\n', @klass.build_options_str(bos_format: '%m\t%f[7]\n'))


### PR DESCRIPTION
`--marginal` only has affect when used in concert with `--theta` during node parsing.

Unit test added that captures this.