### PR TITLE
Speed up for accessing field of Struct.

### DIFF
--- a/lib/natto/struct.rb
+++ b/lib/natto/struct.rb
@@ -15,7 +15,8 @@ module Natto
     # @raise [NoMethodError] if `attr_name` is not a member of this MeCab struct 
     def method_missing(attr_name)
       member_sym = attr_name.id2name.to_sym
-      return self[member_sym] if self.members.include?(member_sym)
+      self[member_sym]
+    rescue ArgumentError # `member_sym` field doesn't exist.
       raise(NoMethodError.new("undefined method '#{attr_name}' for #{self}"))
     end
   end


### PR DESCRIPTION
Optimise accessing to struct field.


## Benchmark

### test code

```ruby
require 'benchmark'
require 'stackprof'
require 'natto'

f = -> (text, n) {
  m = Natto::MeCab.new
  n.times{m.enum_parse(text).to_a}
}

short = '吾輩は猫である。名前はまだ無い。'
long = <<'TXT'
吾輩は猫である。名前はまだ無い。
　どこで生れたかとんと見当がつかぬ。何でも薄暗いじめじめした所でニャーニャー泣いていた事だけは記憶している。吾輩はここで始めて人間というものを見た。しかもあとで聞くとそれは書生という人間中で一番獰悪な種族であったそうだ。この書生というのは時々我々を捕えて煮て食うという話である。しかしその当時は何という考もなかったから別段恐しいとも思わなかった。ただ彼の掌に載せられてスーと持ち上げられた時何だかフワフワした感じがあったばかりである。掌の上で少し落ちついて書生の顔を見たのがいわゆる人間というものの見始であろう。この時妙なものだと思った感じが今でも残っている。第一毛をもって装飾されべきはずの顔がつるつるしてまるで薬缶だ。その後猫にもだいぶ逢ったがこんな片輪には一度も出会わした事がない。のみならず顔の真中があまりに突起している。そうしてその穴の中から時々ぷうぷうと煙を吹く。どうも咽せぽくて実に弱った。これが人間の飲む煙草というものである事はようやくこの頃知った。
　この書生の掌の裏でしばらくはよい心持に坐っておったが、しばらくすると非常な速力で運転し始めた。書生が動くのか自分だけが動くのか分らないが無暗に眼が廻る。胸が悪くなる。到底助からないと思っていると、どさりと音がして眼から火が出た。それまでは記憶しているがあとは何の事やらいくら考え出そうとしても分らない。
　ふと気が付いて見ると書生はいない。たくさんおった兄弟が一疋も見えぬ。肝心の母親さえ姿を隠してしまった。その上今までの所とは違って無暗に明るい。眼を明いていられぬくらいだ。はてな何でも容子がおかしいと、のそのそ這い出して見ると非常に痛い。吾輩は藁の上から急に笹原の中へ棄てられたのである。
　ようやくの思いで笹原を這い出すと向うに大きな池がある。吾輩は池の前に坐ってどうしたらよかろうと考えて見た。別にこれという分別も出ない。しばらくして泣いたら書生がまた迎に来てくれるかと考え付いた。ニャー、ニャーと試みにやって見たが誰も来ない。そのうち池の上をさらさらと風が渡って日が暮れかかる。腹が非常に減って来た。泣きたくても声が出ない。仕方がない、何でもよいから食物のある所まであるこうと決心をしてそろりそろりと池を左りに廻り始めた。どうも非常に苦しい。そこを我慢して無理やりに這って行くとようやくの事で何となく人間臭い所へ出た。ここへ這入ったら、どうにかなると思って竹垣の崩れた穴から、とある邸内にもぐり込んだ。縁は不思議なもので、もしこの竹垣が破れていなかったなら、吾輩はついに路傍に餓死したかも知れんのである。一樹の蔭とはよく云ったものだ。この垣根の穴は今日に至るまで吾輩が隣家の三毛を訪問する時の通路になっている。さて邸へは忍び込んだもののこれから先どうして善いか分らない。そのうちに暗くなる、腹は減る、寒さは寒し、雨が降って来るという始末でもう一刻の猶予が出来なくなった。仕方がないからとにかく明るくて暖かそうな方へ方へとあるいて行く。今から考えるとその時はすでに家の内に這入っておったのだ。ここで吾輩は彼の書生以外の人間を再び見るべき機会に遭遇したのである。第一に逢ったのがおさんである。これは前の書生より一層乱暴な方で吾輩を見るや否やいきなり頸筋をつかんで表へ抛り出した。いやこれは駄目だと思ったから眼をねぶって運を天に任せていた。しかしひもじいのと寒いのにはどうしても我慢が出来ん。吾輩は再びおさんの隙を見て台所へ這い上った。すると間もなくまた投げ出された。吾輩は投げ出されては這い上り、這い上っては投げ出され、何でも同じ事を四五遍繰り返したのを記憶している。その時におさんと云う者はつくづくいやになった。この間おさんの三馬を偸んでこの返報をしてやってから、やっと胸の痞が下りた。吾輩が最後につまみ出されようとしたときに、この家の主人が騒々しい何だといいながら出て来た。下女は吾輩をぶら下げて主人の方へ向けてこの宿なしの小猫がいくら出しても出しても御台所へ上って来て困りますという。主人は鼻の下の黒い毛を撚りながら吾輩の顔をしばらく眺めておったが、やがてそんなら内へ置いてやれといったまま奥へ這入ってしまった。主人はあまり口を聞かぬ人と見えた。下女は口惜しそうに吾輩を台所へ抛り出した。かくして吾輩はついにこの家を自分の住家と極める事にしたのである。
TXT

Benchmark.bm do |x|
  x.report("Short Text:"){f.(short, 50000)}
  x.report("Long Text:"){f.(long, 100)}
end


StackProf.run(mode: :cpu, out: 'stackprof-out-short') do
  f.(short, 50000)
end

StackProf.run(mode: :cpu, out: 'stackprof-out-long') do
  f.(long, 100)
end

```


### Before



```sh
$ ruby test.rb
       user     system      total        real
Short Text:  2.870000   0.010000   2.880000 (  2.879186)
Long Text:  3.840000   0.000000   3.840000 (  3.850516)
```

```sh
$ stackprof stackprof-out-short
==================================
  Mode: cpu(1000)
  Samples: 940 (100.00% miss rate)
  GC: 203 (21.60%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      1436 (152.8%)         242  (25.7%)     Natto::MeCab#initialize
       226  (24.0%)         226  (24.0%)     FFI::Struct.members
       150  (16.0%)         150  (16.0%)     Natto::MeCabNode#initialize
       329  (35.0%)         103  (11.0%)     Natto::MeCabStruct#method_missing
       737  (78.4%)           7   (0.7%)     block (2 levels) in <main>
       163  (17.3%)           6   (0.6%)     Natto::MeCabNode#is_bos?
        18   (1.9%)           3   (0.3%)     Natto::MeCab#enum_parse
       737  (78.4%)           0   (0.0%)     block in <main>
       737  (78.4%)           0   (0.0%)     block in <main>
       737  (78.4%)           0   (0.0%)     <main>
       737  (78.4%)           0   (0.0%)     <main>
       226  (24.0%)           0   (0.0%)     FFI::Struct#members
```

```sh
$ stackprof stackprof-out-long
==================================
  Mode: cpu(1000)
  Samples: 1181 (0.00% miss rate)
  GC: 84 (7.11%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
       935  (79.2%)         935  (79.2%)     FFI::Struct.members
      2190 (185.4%)         103   (8.7%)     Natto::MeCab#initialize
        45   (3.8%)          45   (3.8%)     Natto::MeCabNode#initialize
       948  (80.3%)          12   (1.0%)     Natto::MeCabStruct#method_missing
      1097  (92.9%)           1   (0.1%)     block (2 levels) in <main>
       936  (79.3%)           1   (0.1%)     FFI::Struct#members
      1097  (92.9%)           0   (0.0%)     block in <main>
      1097  (92.9%)           0   (0.0%)     block in <main>
      1097  (92.9%)           0   (0.0%)     <main>
      1097  (92.9%)           0   (0.0%)     <main>
        23   (1.9%)           0   (0.0%)     Natto::MeCabNode#is_bos?
         2   (0.2%)           0   (0.0%)     Natto::MeCab#enum_parse
```

### slow code

```sh
$ stackprof stackprof-out-long --method 'Natto::MeCabStruct#method_missing'
Natto::MeCabStruct#method_missing (/home/pocke/.gem/ruby/2.3.0/gems/natto-1.1.0/lib/natto/struct.rb:16)
  samples:    12 self (1.0%)  /    948 total (80.3%)
  callers:
     925  (   97.6%)  Natto::MeCab#initialize
      23  (    2.4%)  Natto::MeCabNode#is_bos?
  callees (936 total):
     936  (  100.0%)  FFI::Struct#members
  code:
                                  |    16  |     def method_missing(attr_name)
                                  |    17  |       member_sym = attr_name.id2name.to_sym
  948   (80.3%) /    12   (1.0%)  |    18  |       return self[member_sym] if self.members.include?(member_sym)
                                  |    19  |       raise(NoMethodError.new("undefined method '#{attr_name}' for #{self}"))
```


### After

```sh
$ ruby test.rb
       user     system      total        real
Short Text:  2.270000   0.000000   2.270000 (  2.277252)
Long Text:  3.820000   0.010000   3.830000 (  3.841299)
```



```sh
$ stackprof stackprof-out-short
==================================
  Mode: cpu(1000)
  Samples: 768 (0.00% miss rate)
  GC: 170 (22.14%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      1163 (151.4%)         245  (31.9%)     Natto::MeCab#initialize
       184  (24.0%)         184  (24.0%)     Natto::MeCabStruct#method_missing
       152  (19.8%)         152  (19.8%)     Natto::MeCabNode#initialize
       598  (77.9%)          11   (1.4%)     block (2 levels) in <main>
        58   (7.6%)           6   (0.8%)     Natto::MeCabNode#is_bos?
       598  (77.9%)           0   (0.0%)     block in <main>
       598  (77.9%)           0   (0.0%)     block in <main>
       598  (77.9%)           0   (0.0%)     <main>
       598  (77.9%)           0   (0.0%)     <main>
         9   (1.2%)           0   (0.0%)     Natto::MeCab#enum_parse
```

```sh
$ stackprof stackprof-out-long
==================================
  Mode: cpu(1000)
  Samples: 1150 (0.00% miss rate)
  GC: 80 (6.96%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
       934  (81.2%)         934  (81.2%)     Natto::MeCabStruct#method_missing
      2139 (186.0%)         101   (8.8%)     Natto::MeCab#initialize
        35   (3.0%)          35   (3.0%)     Natto::MeCabNode#initialize
      1070  (93.0%)           0   (0.0%)     block (2 levels) in <main>
      1070  (93.0%)           0   (0.0%)     block in <main>
      1070  (93.0%)           0   (0.0%)     block in <main>
      1070  (93.0%)           0   (0.0%)     <main>
      1070  (93.0%)           0   (0.0%)     <main>
        15   (1.3%)           0   (0.0%)     Natto::MeCabNode#is_bos?
         1   (0.1%)           0   (0.0%)     Natto::MeCab#enum_parse
```


### result

|       | before   | after    |
|-------|----------|----------|
| short | 2.879186 | 2.277252 |
| long  | 3.850516 | 3.841299 |

