### PR TITLE
Refactor test

### DIFF
--- a/test/natto/tc_dictionaryinfo.rb
+++ b/test/natto/tc_dictionaryinfo.rb
@@ -4,6 +4,7 @@ require 'rbconfig'
 
 class TestDictionaryInfo < Minitest::Test
   def setup
+    @testdic = File.join(Dir.pwd, 'test', 'natto', 'test.dic')
     begin
       File.delete(@testdic) if File.exist?(@testdic)
     rescue
@@ -13,7 +14,6 @@ class TestDictionaryInfo < Minitest::Test
     @host_os = RbConfig::CONFIG['host_os']
 
     testcsv = File.join(Dir.pwd, 'test', 'natto', 'test_userdic.csv')
-    @testdic = File.join(Dir.pwd, 'test', 'natto', 'test.dic')
     
     if @host_os =~ /mswin|mingw/i
       require 'win32/registry'

--- a/test/natto/tc_dictionaryinfo.rb
+++ b/test/natto/tc_dictionaryinfo.rb
@@ -12,8 +12,6 @@ class TestDictionaryInfo < Minitest::Test
 
     @host_os = RbConfig::CONFIG['host_os']
 
-    usrdic, m = nil,nil
-
     testcsv = File.join(Dir.pwd, 'test', 'natto', 'test_userdic.csv')
     @testdic = File.join(Dir.pwd, 'test', 'natto', 'test.dic')
     
@@ -58,8 +56,6 @@ class TestDictionaryInfo < Minitest::Test
 
     @usrdic_filename = out[8].split("\t")[1].strip
     @usrdic_filepath = File.absolute_path(@usrdic_filename)
-    :q
-    :q
     @usrdic_charset  = out[10].split("\t")[1].strip
     @usrdic_type     = out[11].split("\t")[1].strip.to_i
   end

--- a/test/natto/tc_dictionaryinfo.rb
+++ b/test/natto/tc_dictionaryinfo.rb
@@ -7,7 +7,7 @@ class TestDictionaryInfo < Minitest::Test
     @testdic = File.join(Dir.pwd, 'test', 'natto', 'test.dic')
     begin
       File.delete(@testdic) if File.exist?(@testdic)
-    rescue
+    rescue SystemCallError
       $stderr.puts "[INFO] setup: could not delete test.dic, you might want to remove manually."
     end
 

--- a/test/natto/tc_mecab.rb
+++ b/test/natto/tc_mecab.rb
@@ -278,7 +278,7 @@ class TestMeCab < Minitest::Test
 
   def test_lattice_level_warning
     [{lattice_level: 999}, '-l 999', '--lattice-level=999' ].each do |opt|
-      out, err = capture_io do
+      _out, err = capture_io do
         Natto::MeCab.new opt
       end
       assert_equal ":lattice-level is DEPRECATED, please use :marginal or :nbest\n", err


### PR DESCRIPTION
This pull request will suppress Ruby warnings in the tests.
Currently this project has some Ruby warnings. We can confirm them with `RUBYOPT=-w`.

```bash
$ RUBYOPT=-w bundle exec rake
/home/pocke/.rbenv/versions/trunk/bin/ruby  test/test_natto.rb 
/home/pocke/ghq/github.com/buruzaemon/natto/test/natto/tc_dictionaryinfo.rb:61: warning: possibly useless use of a literal in void context
/home/pocke/ghq/github.com/buruzaemon/natto/test/natto/tc_dictionaryinfo.rb:62: warning: possibly useless use of a literal in void context
/home/pocke/ghq/github.com/buruzaemon/natto/test/natto/tc_dictionaryinfo.rb:15: warning: assigned but unused variable - usrdic
/home/pocke/ghq/github.com/buruzaemon/natto/test/natto/tc_mecab.rb:281: warning: assigned but unused variable - out
Run options: --seed 63625

# Running:

..........:lattice-level is DEPRECATED, please use :marginal or :nbest
:lattice-level is DEPRECATED, please use :marginal or :nbest
:lattice-level is DEPRECATED, please use :marginal or :nbest
:lattice-level is DEPRECATED, please use :marginal or :nbest
:lattice-level is DEPRECATED, please use :marginal or :nbest
.........................../home/pocke/ghq/github.com/buruzaemon/natto/test/natto/tc_dictionaryinfo.rb:8: warning: instance variable @testdic not initialized
[INFO] setup: could not delete test.dic, you might want to remove manually.
reading /home/pocke/ghq/github.com/buruzaemon/natto/test/natto/test_userdic.csv ... 1
emitting double-array: 100% |###########################################| 

done!
./home/pocke/ghq/github.com/buruzaemon/natto/test/natto/tc_dictionaryinfo.rb:8: warning: instance variable @testdic not initialized
[INFO] setup: could not delete test.dic, you might want to remove manually.
reading /home/pocke/ghq/github.com/buruzaemon/natto/test/natto/test_userdic.csv ... 1
emitting double-array: 100% |###########################################| 

done!
/home/pocke/ghq/github.com/buruzaemon/natto/test/natto/tc_dictionaryinfo.rb:8: warning: instance variable @testdic not initialized
[INFO] setup: could not delete test.dic, you might want to remove manually.
.reading /home/pocke/ghq/github.com/buruzaemon/natto/test/natto/test_userdic.csv ... 1
emitting double-array: 100% |###########################################| 

done!
/home/pocke/ghq/github.com/buruzaemon/natto/test/natto/tc_dictionaryinfo.rb:8: warning: instance variable @testdic not initialized
[INFO] setup: could not delete test.dic, you might want to remove manually.
.reading /home/pocke/ghq/github.com/buruzaemon/natto/test/natto/test_userdic.csv ... 1
emitting double-array: 100% |###########################################| 

done!
...:lattice-level is DEPRECATED, please use :marginal or :nbest
:lattice-level is DEPRECATED, please use :marginal or :nbest
:lattice-level is DEPRECATED, please use :marginal or :nbest
:lattice-level is DEPRECATED, please use :marginal or :nbest
:lattice-level is DEPRECATED, please use :marginal or :nbest
.

Finished in 1.037865s, 42.3947 runs/s, 611.8331 assertions/s.

44 runs, 635 assertions, 0 failures, 0 errors, 0 skips
```


After this pull request, it displays test result without Ruby warnings.

```bash
$ RUBYOPT=-w bundle exec rake 
/home/pocke/.rbenv/versions/trunk/bin/ruby  test/test_natto.rb 
Run options: --seed 29586

# Running:

....:lattice-level is DEPRECATED, please use :marginal or :nbest
:lattice-level is DEPRECATED, please use :marginal or :nbest
:lattice-level is DEPRECATED, please use :marginal or :nbest
:lattice-level is DEPRECATED, please use :marginal or :nbest
:lattice-level is DEPRECATED, please use :marginal or :nbest
...............................reading /home/pocke/ghq/github.com/buruzaemon/natto/test/natto/test_userdic.csv ... 1
emitting double-array: 100% |###########################################| 

done!
.reading /home/pocke/ghq/github.com/buruzaemon/natto/test/natto/test_userdic.csv ... 1
emitting double-array: 100% |###########################################| 

done!
.reading /home/pocke/ghq/github.com/buruzaemon/natto/test/natto/test_userdic.csv ... 1
emitting double-array: 100% |###########################################| 

done!
.reading /home/pocke/ghq/github.com/buruzaemon/natto/test/natto/test_userdic.csv ... 1
emitting double-array: 100% |###########################################| 

done!
.....:lattice-level is DEPRECATED, please use :marginal or :nbest
:lattice-level is DEPRECATED, please use :marginal or :nbest
:lattice-level is DEPRECATED, please use :marginal or :nbest
:lattice-level is DEPRECATED, please use :marginal or :nbest
:lattice-level is DEPRECATED, please use :marginal or :nbest
.

Finished in 1.064655s, 41.3279 runs/s, 596.4374 assertions/s.

44 runs, 635 assertions, 0 failures, 0 errors, 0 skips
```