### PR TITLE
Do not conceal original error in `parse_tostr` and `parse_tonodes`

### DIFF
--- a/lib/natto/natto.rb
+++ b/lib/natto/natto.rb
@@ -335,8 +335,10 @@ module Natto
             retval = self.mecab_lattice_tostr(@lattice)
           end
           retval.force_encoding(Encoding.default_external)
-        rescue
-          raise(MeCabError.new(self.mecab_lattice_strerror(@lattice))) 
+        rescue => ex
+          message = self.mecab_lattice_strerror(@lattice)
+          raise ex if message == ''
+          raise MeCabError.new(message)
         end
       }
         
@@ -416,8 +418,10 @@ module Natto
               end
             end
             nil
-          rescue
-            raise(MeCabError.new(self.mecab_lattice_strerror(@lattice))) 
+          rescue => ex
+            message = self.mecab_lattice_strerror(@lattice)
+            raise ex if message == ''
+            raise MeCabError.new(message)
           end
         end
       }

--- a/test/natto/tc_mecab.rb
+++ b/test/natto/tc_mecab.rb
@@ -479,6 +479,15 @@ class TestMeCab < Minitest::Test
     end
   end
 
+  # regression test for https://github.com/buruzaemon/natto/pull/73
+  def test_parse_tostr_does_not_conceal_error
+    nm = Natto::MeCab.new
+    error_cause = Object.new
+    assert_raises TypeError do
+      nm.parse(error_cause)
+    end
+  end
+
   # ----------- tonodes --------------------------
   
   def test_parse_tonodes_default
@@ -645,6 +654,17 @@ class TestMeCab < Minitest::Test
     nm.enum_parse(@test_fc, feature_constraints: @test_fc_hash).each {|n| actual << n}
     actual.each_with_index do |n,i|
       assert_match(@test_fc_res[i], n.feature)
+    end
+  end
+
+  # regression test for https://github.com/buruzaemon/natto/pull/73
+  def test_parse_tonodes_does_not_conceal_error
+    nm = Natto::MeCab.new
+    error_cause = Object.new
+    assert_raises TypeError do
+      nm.parse(error_cause) do
+        # nothing
+      end
     end
   end
 


### PR DESCRIPTION
Problem
===

`parse_tostr` and `parse_tonodes` conceal errors when not mecab error is occurred in these methods.


Solution
===

Raise the original error if lattice strerror is empty.

## Another approach

Probably specifying error class(es) in `rescue` is better approach, but I'm not sure which error classes are raised. So I gave up the approach.